### PR TITLE
Fix `FileHandle.resize(0L)` on mingwX64

### DIFF
--- a/okio-testing-support/src/commonMain/kotlin/okio/AbstractFileSystemTest.kt
+++ b/okio-testing-support/src/commonMain/kotlin/okio/AbstractFileSystemTest.kt
@@ -1736,6 +1736,20 @@ abstract class AbstractFileSystemTest(
     }
   }
 
+  @Test fun fileHandleResizeToZero() {
+    val path = base / "file-handle-resize-to-zero"
+    fileSystem.openReadWrite(path).use { handle ->
+
+      handle.sink().buffer().use { sink ->
+        sink.writeUtf8("abcde")
+      }
+
+      handle.resize(0L)
+
+      assertEquals(0L, handle.size())
+    }
+  }
+
   @Test fun fileHandleResizeLarger() {
     val path = base / "file-handle-resize-larger"
     fileSystem.openReadWrite(path).use { handle ->

--- a/okio/src/mingwX64Main/kotlin/okio/WindowsFileHandle.kt
+++ b/okio/src/mingwX64Main/kotlin/okio/WindowsFileHandle.kt
@@ -30,7 +30,9 @@ import platform.windows.FlushFileBuffers
 import platform.windows.GetFileSizeEx
 import platform.windows.GetLastError
 import platform.windows.HANDLE
+import platform.windows.INVALID_SET_FILE_POINTER
 import platform.windows.LARGE_INTEGER
+import platform.windows.NO_ERROR
 import platform.windows.ReadFile
 import platform.windows.SetEndOfFile
 import platform.windows.SetFilePointer
@@ -146,7 +148,7 @@ internal class WindowsFileHandle(
         lpDistanceToMoveHigh = distanceToMoveHigh.ptr,
         dwMoveMethod = FILE_BEGIN.toUInt(),
       )
-      if (movePointerResult == 0U) {
+      if (movePointerResult == INVALID_SET_FILE_POINTER && GetLastError().toInt() != NO_ERROR) {
         throw lastErrorToIOException()
       }
       if (SetEndOfFile(file) == 0) {


### PR DESCRIPTION
`SetFilePointer()` returns the low-order file position, so zero is valid when resizing a file to zero bytes. Treat only `INVALID_SET_FILE_POINTER` with a non-`NO_ERROR` last error as failure.

Resolve https://github.com/lysine-dev/okio/issues/1844