### PR TITLE
New 'No Generative Tools' section in contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,34 @@
 Contributing
 ============
 
+Our goal with this project is to build a simple, fast, and secure component that you can trust. We
+have scoped the project deliberately to address common use cases easily, and made it extensible so
+it'll handle exotic use cases too.
+
 Keeping the project small and stable limits our ability to accept new contributors. We are not
 seeking new committers at this time, but some small contributions are welcome.
 
-If you've found a security problem, please follow our [bug bounty][security] program.
-
 If you've found a bug, please contribute a failing test case so we can study and fix it.
 
-Before code can be accepted all contributors must complete our
-[Individual Contributor License Agreement (CLA)][cla].
+
+No Generative Tools
+-------------------
+
+We don't use LLMs or generative tools in our source code or documentation. We don't use them for
+human-to-human communication in commits, issues, and pull requests. We believe writing is thinking,
+and want our work to be thoughtful.
+
+We require all contributors to do likewise. Building is more fun when everyone is making an effort.
+
+We’ll immediately reject LLM-generated contributions to protect the culture of our project. We ban
+repeat offenders.
+
+Some narrow exceptions to this policy:
+
+* Non-English speakers may use machine translation tools if they are disclosed.
+* Local autocomplete. (Avoid tools that are metered in tokens.)
+
+Coding is fun.
 
 
 Code Contributions
@@ -33,6 +52,4 @@ Committer's Guides
 
  * [Releasing][releasing]
 
- [cla]: https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1
  [releasing]: https://lysine.dev/okio/releasing/
- [security]: https://lysine.dev/okio/security/


### PR DESCRIPTION
Also drop the link to Square's CLA and bug bounty, which are no longer part of this project.