### PR TITLE
Migrated JVM tests from JUnit 4 to JUnit 5

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -138,6 +138,10 @@ subprojects {
     }
   }
 
+  tasks.withType<Test> {
+    useJUnitPlatform()
+  }
+
   tasks.withType<AbstractKotlinCompile<*>>().configureEach {
     compilerOptions.apply {
       freeCompilerArgs.add("-Xexpect-actual-classes")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ jmh-generator = { module = "org.openjdk.jmh:jmh-generator-annprocess", version.r
 jmh-gradle-plugin = { module = "me.champeau.jmh:jmh-gradle-plugin", version = "0.7.3" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
-kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
+kotlin-test-junit5 = { module = "org.jetbrains.kotlin:kotlin-test-junit5", version.ref = "kotlin" }
 kotlin-time = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version = "0.8.0-0.6.x-compat" }
 spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version = "8.0.0" }
 tapmoc-gradle-plugin = { module =  "com.gradleup.tapmoc:com.gradleup.tapmoc.gradle.plugin", version = "0.4.2"}
@@ -29,5 +29,4 @@ test-assertk = "com.willowtreeapps.assertk:assertk:0.28.1"
 test-jimfs = "com.google.jimfs:jimfs:1.3.2"
 test-junit = { module = "junit:junit", version = "4.13.2" }
 test-junit5 = { module = "org.junit.jupiter:junit-jupiter-api", version = "5.13.4" }
-test-junit-vintage = {module = "org.junit.vintage:junit-vintage-engine", version = "5.13.4"}
 vanniktech-publish-plugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.37.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,4 +28,6 @@ tapmoc-gradle-plugin = { module =  "com.gradleup.tapmoc:com.gradleup.tapmoc.grad
 test-assertk = "com.willowtreeapps.assertk:assertk:0.28.1"
 test-jimfs = "com.google.jimfs:jimfs:1.3.2"
 test-junit = { module = "junit:junit", version = "4.13.2" }
+test-junit5 = { module = "org.junit.jupiter:junit-jupiter-api", version = "5.13.4" }
+test-junit-vintage = {module = "org.junit.vintage:junit-vintage-engine", version = "5.13.4"}
 vanniktech-publish-plugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.37.0" }

--- a/okio-testing-support/build.gradle.kts
+++ b/okio-testing-support/build.gradle.kts
@@ -50,7 +50,7 @@ kotlin {
         // On the JVM the kotlin-test library resolves to one of three implementations based on
         // which testing framework is in use. JUnit is used downstream, but Gradle can't know that
         // here and thus fails to select a variant automatically. Declare it manually instead.
-        api(libs.kotlin.test.junit)
+        api(libs.kotlin.test.junit5)
       }
     }
 

--- a/okio-testing-support/src/jvmMain/kotlin/okio/TestingJvm.kt
+++ b/okio-testing-support/src/jvmMain/kotlin/okio/TestingJvm.kt
@@ -15,6 +15,10 @@
  */
 package okio
 
+import java.io.File
+
 actual fun isBrowser() = false
 
 actual fun getEnv(name: String): String? = System.getenv(name)
+
+fun File.newFile(): File = File.createTempFile("tmp_file", null, this)

--- a/okio/build.gradle.kts
+++ b/okio/build.gradle.kts
@@ -133,7 +133,8 @@ kotlin {
       dependsOn(nonWasmTest)
       dependsOn(zlibTest)
       dependencies {
-        implementation(libs.test.junit)
+        implementation(libs.test.junit5)
+        implementation(libs.test.junit.vintage)
         implementation(libs.test.jimfs)
       }
     }

--- a/okio/build.gradle.kts
+++ b/okio/build.gradle.kts
@@ -236,10 +236,6 @@ kotlin {
 }
 
 tasks {
-  withType<Test> {
-    useJUnitPlatform()
-  }
-
   val jvmJar by getting(Jar::class) {
     // BundleTaskExtension() crashes unless there's a 'main' source set.
     sourceSets.create(SourceSet.MAIN_SOURCE_SET_NAME)

--- a/okio/build.gradle.kts
+++ b/okio/build.gradle.kts
@@ -134,7 +134,6 @@ kotlin {
       dependsOn(zlibTest)
       dependencies {
         implementation(libs.test.junit5)
-        implementation(libs.test.junit.vintage)
         implementation(libs.test.jimfs)
       }
     }
@@ -237,6 +236,10 @@ kotlin {
 }
 
 tasks {
+  withType<Test> {
+    useJUnitPlatform()
+  }
+
   val jvmJar by getting(Jar::class) {
     // BundleTaskExtension() crashes unless there's a 'main' source set.
     sourceSets.create(SourceSet.MAIN_SOURCE_SET_NAME)

--- a/okio/src/jvmTest/kotlin/okio/AsyncTimeoutTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/AsyncTimeoutTest.kt
@@ -22,14 +22,14 @@ import java.util.concurrent.LinkedBlockingDeque
 import java.util.concurrent.TimeUnit
 import okio.ByteString.Companion.of
 import okio.TestUtil.bufferWithRandomSegmentLayout
-import org.junit.Assert
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Assert.fail
-import org.junit.Before
-import org.junit.Ignore
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
 
 /**
  * This test uses four timeouts of varying durations: 250ms, 500ms, 750ms and
@@ -42,7 +42,7 @@ class AsyncTimeoutTest {
   private val c = RecordingAsyncTimeout()
   private val d = RecordingAsyncTimeout()
 
-  @Before
+  @BeforeEach
   fun setUp() {
     a.timeout(250, TimeUnit.MILLISECONDS)
     b.timeout(500, TimeUnit.MILLISECONDS)
@@ -154,7 +154,7 @@ class AsyncTimeoutTest {
   fun reEnterAfterTimeout() {
     a.timeout(1, TimeUnit.MILLISECONDS)
     a.enter()
-    Assert.assertSame(a, timedOut.take())
+    Assertions.assertSame(a, timedOut.take())
     assertTrue(a.exit())
     a.enter()
     assertFalse(a.exit())
@@ -345,7 +345,7 @@ class AsyncTimeoutTest {
    * unexpected timeout because although the sink was making steady forward
    * progress, doing it all as a single write caused a timeout.
    */
-  @Ignore("Flaky")
+  @Disabled("Flaky")
   @Test
   fun sinkSplitsLargeWrites() {
     val data = ByteArray(512 * 1024)

--- a/okio/src/jvmTest/kotlin/okio/AwaitSignalTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/AwaitSignalTest.kt
@@ -23,10 +23,10 @@ import java.util.concurrent.locks.Condition
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.time.Duration.Companion.milliseconds
 import okio.TestUtil.assumeNotWindows
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Assert.fail
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
 
 @Burst
 class AwaitSignalTest(

--- a/okio/src/jvmTest/kotlin/okio/BufferCursorKotlinTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/BufferCursorKotlinTest.kt
@@ -16,15 +16,15 @@
 package okio
 
 import app.cash.burst.Burst
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertNotSame
 import kotlin.test.assertSame
-import kotlin.test.assertTrue
 import okio.Buffer.UnsafeCursor
 import okio.TestUtil.deepCopy
-import org.junit.Assume.assumeTrue
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
 
 @Burst
 class BufferCursorKotlinTest(

--- a/okio/src/jvmTest/kotlin/okio/BufferCursorTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/BufferCursorTest.kt
@@ -22,9 +22,9 @@ import okio.TestUtil.SEGMENT_SIZE
 import okio.TestUtil.deepCopy
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test

--- a/okio/src/jvmTest/kotlin/okio/BufferCursorTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/BufferCursorTest.kt
@@ -20,14 +20,14 @@ import java.util.Arrays
 import okio.ByteString.Companion.of
 import okio.TestUtil.SEGMENT_SIZE
 import okio.TestUtil.deepCopy
-import org.junit.Assert
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
-import org.junit.Assert.fail
-import org.junit.Assume.assumeTrue
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
 
 @Burst
 class BufferCursorTest(
@@ -125,7 +125,7 @@ class BufferCursorTest(
     try {
       var lastOffset = cursor.offset
       while (cursor.next().toLong() != -1L) {
-        Assert.assertTrue(cursor.offset > lastOffset)
+        Assertions.assertTrue(cursor.offset > lastOffset)
         lastOffset = cursor.offset
       }
       assertEquals(buffer.size, cursor.offset)

--- a/okio/src/jvmTest/kotlin/okio/BufferKotlinTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/BufferKotlinTest.kt
@@ -18,7 +18,7 @@ package okio
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import kotlin.test.assertFailsWith
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class BufferKotlinTest {
   @Test fun get() {

--- a/okio/src/jvmTest/kotlin/okio/BufferTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/BufferTest.kt
@@ -28,10 +28,10 @@ import okio.TestUtil.SEGMENT_SIZE
 import okio.TestUtil.bufferWithRandomSegmentLayout
 import okio.TestUtil.segmentPoolByteCount
 import okio.TestUtil.segmentSizes
-import org.junit.Assert
-import org.junit.Assert.assertEquals
-import org.junit.Assert.fail
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
 
 /**
  * Tests solely for the behavior of Buffer's implementation. For generic BufferedSink or
@@ -450,8 +450,8 @@ class BufferTest {
   fun equalsAndHashCode() {
     val a = Buffer().writeUtf8("dog")
     val b = Buffer().writeUtf8("hotdog")
-    Assert.assertNotEquals(a, b)
-    Assert.assertNotEquals(a.hashCode().toLong(), b.hashCode().toLong())
+    Assertions.assertNotEquals(a, b)
+    Assertions.assertNotEquals(a.hashCode().toLong(), b.hashCode().toLong())
     b.readUtf8(3) // Leaves b containing 'dog'.
     assertEquals(a, b)
     assertEquals(a.hashCode().toLong(), b.hashCode().toLong())
@@ -468,8 +468,8 @@ class BufferTest {
     assertEquals(a.hashCode().toLong(), b.hashCode().toLong())
     data[data.size / 2]++ // Change a single byte.
     val c = bufferWithRandomSegmentLayout(dice, data)
-    Assert.assertNotEquals(a, c)
-    Assert.assertNotEquals(a.hashCode().toLong(), c.hashCode().toLong())
+    Assertions.assertNotEquals(a, c)
+    Assertions.assertNotEquals(a.hashCode().toLong(), c.hashCode().toLong())
   }
 
   @Test

--- a/okio/src/jvmTest/kotlin/okio/BufferedSinkJavaTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/BufferedSinkJavaTest.kt
@@ -17,9 +17,9 @@ package okio
 
 import java.io.IOException
 import okio.TestUtil.SEGMENT_SIZE
-import org.junit.Assert.assertEquals
-import org.junit.Assert.fail
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
 
 /**
  * Tests solely for the behavior of RealBufferedSink's implementation. For generic

--- a/okio/src/jvmTest/kotlin/okio/BufferedSinkTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/BufferedSinkTest.kt
@@ -25,9 +25,9 @@ import okio.ByteString.Companion.decodeHex
 import okio.ByteString.Companion.encodeUtf8
 import okio.TestUtil.SEGMENT_SIZE
 import okio.TestUtil.segmentSizes
-import org.junit.Assert.assertEquals
-import org.junit.Assert.fail
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
 
 @Burst
 class BufferedSinkTest(
@@ -324,7 +324,7 @@ class BufferedSinkTest(
     sink.writeDecimalLong(value).writeUtf8("zzz").flush()
     val expected = java.lang.Long.toString(value) + "zzz"
     val actual = data.readUtf8()
-    assertEquals("$value expected $expected but was $actual", actual, expected)
+    assertEquals(actual, expected, "$value expected $expected but was $actual")
   }
 
   @Test
@@ -370,6 +370,6 @@ class BufferedSinkTest(
     sink.writeHexadecimalUnsignedLong(value).writeUtf8("zzz").flush()
     val expected = String.format("%x", value) + "zzz"
     val actual = data.readUtf8()
-    assertEquals("$value expected $expected but was $actual", actual, expected)
+    assertEquals(actual, expected, "$value expected $expected but was $actual")
   }
 }

--- a/okio/src/jvmTest/kotlin/okio/BufferedSourceJavaTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/BufferedSourceJavaTest.kt
@@ -19,9 +19,9 @@ import java.io.EOFException
 import java.io.IOException
 import kotlin.text.Charsets.UTF_8
 import okio.TestUtil.SEGMENT_SIZE
-import org.junit.Assert.assertEquals
-import org.junit.Assert.fail
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
 
 /**
  * Tests solely for the behavior of RealBufferedSource's implementation. For generic

--- a/okio/src/jvmTest/kotlin/okio/BufferedSourceTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/BufferedSourceTest.kt
@@ -35,12 +35,12 @@ import okio.TestUtil.assertByteArrayEquals
 import okio.TestUtil.assertByteArraysEquals
 import okio.TestUtil.randomBytes
 import okio.TestUtil.segmentSizes
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Assert.fail
-import org.junit.Assume.assumeTrue
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
 
 @Burst
 class BufferedSourceTest(
@@ -1227,7 +1227,7 @@ class BufferedSourceTest(
     sink.writeUtf8(s)
     sink.emit()
     val actual = source.readHexadecimalUnsignedLong()
-    assertEquals("$s --> $expected", expected, actual)
+    assertEquals(expected, actual, "$s --> $expected")
   }
 
   @Test
@@ -1289,7 +1289,7 @@ class BufferedSourceTest(
     sink.writeUtf8("zzz")
     sink.emit()
     val actual = source.readDecimalLong()
-    assertEquals("$s --> $expected", expected, actual)
+    assertEquals(expected, actual, "$s --> $expected")
     assertEquals("zzz", source.readUtf8())
   }
 

--- a/okio/src/jvmTest/kotlin/okio/ByteStringJavaTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/ByteStringJavaTest.kt
@@ -33,8 +33,8 @@ import okio.TestUtil.assertByteArraysEquals
 import okio.TestUtil.assertEquivalent
 import okio.TestUtil.makeSegments
 import okio.TestUtil.reserialize
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 @Burst
 class ByteStringJavaTest(

--- a/okio/src/jvmTest/kotlin/okio/CipherSinkTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/CipherSinkTest.kt
@@ -17,7 +17,7 @@ package okio
 
 import app.cash.burst.Burst
 import kotlin.random.Random
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 @Burst
 class CipherSinkTest(

--- a/okio/src/jvmTest/kotlin/okio/CipherSourceTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/CipherSourceTest.kt
@@ -17,7 +17,7 @@ package okio
 
 import app.cash.burst.Burst
 import kotlin.random.Random
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 @Burst
 class CipherSourceTest(

--- a/okio/src/jvmTest/kotlin/okio/ConstantTimeEqualsTimingTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/ConstantTimeEqualsTimingTest.kt
@@ -59,13 +59,13 @@ class ConstantTimeEqualsTimingTest {
       if (ctMatch > ctMismatch) ctMatch.toDouble() / ctMismatch else ctMismatch.toDouble() / ctMatch
     assertTrue(
       ctRatio < 3.0,
-      "CT(match)=$ctMatch ns and CT(mismatch)=$ctMismatch ns differ by ${ctRatio}x (expected <3x)"
+      "CT(match)=$ctMatch ns and CT(mismatch)=$ctMismatch ns differ by ${ctRatio}x (expected <3x)",
     )
 
     // normal(mismatch) must be significantly faster than CT(mismatch): normal short-circuits at byte 0.
     assertTrue(
       normalMismatch * 50L < ctMismatch,
-      "normal(mismatch)=$normalMismatch ns should be <2% of CT(mismatch)=$ctMismatch ns (short-circuit at byte 0)"
+      "normal(mismatch)=$normalMismatch ns should be <2% of CT(mismatch)=$ctMismatch ns (short-circuit at byte 0)",
     )
   }
 

--- a/okio/src/jvmTest/kotlin/okio/ConstantTimeEqualsTimingTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/ConstantTimeEqualsTimingTest.kt
@@ -16,8 +16,8 @@
 package okio
 
 import okio.ByteString.Companion.toByteString
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 
 /**
  * Statistical timing test for [ByteString.equals] with [constantTime]=true.
@@ -58,14 +58,14 @@ class ConstantTimeEqualsTimingTest {
     val ctRatio =
       if (ctMatch > ctMismatch) ctMatch.toDouble() / ctMismatch else ctMismatch.toDouble() / ctMatch
     assertTrue(
-      "CT(match)=$ctMatch ns and CT(mismatch)=$ctMismatch ns differ by ${ctRatio}x (expected <3x)",
       ctRatio < 3.0,
+      "CT(match)=$ctMatch ns and CT(mismatch)=$ctMismatch ns differ by ${ctRatio}x (expected <3x)"
     )
 
     // normal(mismatch) must be significantly faster than CT(mismatch): normal short-circuits at byte 0.
     assertTrue(
-      "normal(mismatch)=$normalMismatch ns should be <2% of CT(mismatch)=$ctMismatch ns (short-circuit at byte 0)",
       normalMismatch * 50L < ctMismatch,
+      "normal(mismatch)=$normalMismatch ns should be <2% of CT(mismatch)=$ctMismatch ns (short-circuit at byte 0)"
     )
   }
 

--- a/okio/src/jvmTest/kotlin/okio/DeflateKotlinTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/DeflateKotlinTest.kt
@@ -20,7 +20,7 @@ import java.util.zip.Deflater
 import java.util.zip.Inflater
 import kotlin.test.assertEquals
 import okio.ByteString.Companion.decodeHex
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class DeflateKotlinTest {
   @Test fun deflate() {

--- a/okio/src/jvmTest/kotlin/okio/DeflaterSinkTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/DeflaterSinkTest.kt
@@ -26,8 +26,8 @@ import java.util.zip.Inflater
 import java.util.zip.InflaterInputStream
 import okio.TestUtil.SEGMENT_SIZE
 import okio.TestUtil.randomBytes
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
 
 class DeflaterSinkTest {
   @Test
@@ -40,7 +40,7 @@ class DeflaterSinkTest {
     deflaterSink.write(data, data.size)
     deflaterSink.close()
     val inflated = inflate(sink)
-    Assert.assertEquals(original, inflated.readUtf8())
+    Assertions.assertEquals(original, inflated.readUtf8())
   }
 
   @Test
@@ -53,7 +53,7 @@ class DeflaterSinkTest {
     deflaterSink.write(data, data.size)
     deflaterSink.flush()
     val inflated = inflate(sink)
-    Assert.assertEquals(original, inflated.readUtf8())
+    Assertions.assertEquals(original, inflated.readUtf8())
   }
 
   @Test
@@ -66,7 +66,7 @@ class DeflaterSinkTest {
     deflaterSink.write(data, data.size)
     deflaterSink.close()
     val inflated = inflate(sink)
-    Assert.assertEquals(original, inflated.readUtf8())
+    Assertions.assertEquals(original, inflated.readUtf8())
   }
 
   @Test
@@ -79,7 +79,7 @@ class DeflaterSinkTest {
     deflaterSink.write(data, data.size)
     deflaterSink.close()
     val inflated = inflate(sink)
-    Assert.assertEquals(original, inflated.readByteString())
+    Assertions.assertEquals(original, inflated.readByteString())
   }
 
   @Test
@@ -91,7 +91,7 @@ class DeflaterSinkTest {
     val byteCount = SEGMENT_SIZE * 4
     deflaterSink.write(Buffer().writeUtf8("a".repeat(byteCount)), byteCount.toLong())
     deflaterSink.close()
-    Assert.assertEquals("a".repeat(byteCount), inflate(buffer).readUtf8(byteCount.toLong()))
+    Assertions.assertEquals("a".repeat(byteCount), inflate(buffer).readUtf8(byteCount.toLong()))
   }
 
   @Test
@@ -107,7 +107,7 @@ class DeflaterSinkTest {
       deflaterSink.close()
       sink.skip(i.toLong())
       val inflated = inflate(sink)
-      Assert.assertEquals(original, inflated.readUtf8())
+      Assertions.assertEquals(original, inflated.readUtf8())
     }
   }
 
@@ -127,9 +127,9 @@ class DeflaterSinkTest {
     deflaterSink.write(Buffer().writeUtf8("a".repeat(SEGMENT_SIZE)), SEGMENT_SIZE.toLong())
     try {
       deflaterSink.close()
-      Assert.fail()
+      Assertions.fail()
     } catch (expected: IOException) {
-      Assert.assertEquals("first", expected.message)
+      Assertions.assertEquals("first", expected.message)
     }
     mockSink.assertLogContains("close()")
   }

--- a/okio/src/jvmTest/kotlin/okio/FileLeakTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/FileLeakTest.kt
@@ -33,8 +33,8 @@ import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
 import okio.internal.ResourceFileSystem
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Assumptions
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 private const val PROC_SELF_FD = "/proc/self/fd"

--- a/okio/src/jvmTest/kotlin/okio/FileLeakTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/FileLeakTest.kt
@@ -32,10 +32,10 @@ import kotlin.test.assertTrue
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
 import okio.internal.ResourceFileSystem
-import org.junit.After
-import org.junit.Assume.assumeTrue
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Assumptions
+import org.junit.jupiter.api.Test
 
 private const val PROC_SELF_FD = "/proc/self/fd"
 
@@ -47,7 +47,7 @@ class FileLeakTest {
   private val fakeDirectory = "/another/".toPath()
   private val fakeEntry2 = fakeDirectory / "another.file"
 
-  @Before
+  @BeforeEach
   fun setup() {
     fakeFileSystem = FakeFileSystem()
     with(fakeFileSystem) {
@@ -69,7 +69,7 @@ class FileLeakTest {
     }
   }
 
-  @After
+  @AfterEach
   fun tearDown() {
     fakeFileSystem.checkNoOpenFiles()
   }
@@ -103,7 +103,7 @@ class FileLeakTest {
 
   @Test
   fun fileLeakInResourceFileSystemTest() {
-    assumeTrue("File descriptor symbolic link available only on Linux", Path(PROC_SELF_FD).exists())
+    Assumptions.assumeTrue(Path(PROC_SELF_FD).exists(), "File descriptor symbolic link available only on Linux")
     // Create a test file that will be opened and cached by the classloader
     val zipPath = ZipBuilder(FileSystem.SYSTEM_TEMPORARY_DIRECTORY / randomToken(16))
       .addEntry("test.txt", "I'm part of a test!")

--- a/okio/src/jvmTest/kotlin/okio/FileSystemJavaTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/FileSystemJavaTest.kt
@@ -30,7 +30,7 @@ import okio.ByteString.Companion.encodeUtf8
 import okio.Path.Companion.toOkioPath
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class FileSystemJavaTest {
   @Test

--- a/okio/src/jvmTest/kotlin/okio/ForwardingTimeoutKotlinTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/ForwardingTimeoutKotlinTest.kt
@@ -19,7 +19,7 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotEqualTo
 import java.util.concurrent.TimeUnit
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class ForwardingTimeoutKotlinTest {
   @Test fun getAndSetDelegate() {

--- a/okio/src/jvmTest/kotlin/okio/ForwardingTimeoutTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/ForwardingTimeoutTest.kt
@@ -19,7 +19,7 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotEqualTo
 import java.util.concurrent.TimeUnit
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class ForwardingTimeoutTest {
   @Test

--- a/okio/src/jvmTest/kotlin/okio/InflaterSourceTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/InflaterSourceTest.kt
@@ -28,10 +28,10 @@ import okio.ByteString.Companion.decodeBase64
 import okio.ByteString.Companion.encodeUtf8
 import okio.TestUtil.SEGMENT_SIZE
 import okio.TestUtil.randomBytes
-import org.junit.Assert.assertEquals
-import org.junit.Assert.fail
-import org.junit.Assume.assumeFalse
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Assumptions.assumeFalse
+import org.junit.jupiter.api.Test
 
 @Burst
 class InflaterSourceTest(

--- a/okio/src/jvmTest/kotlin/okio/JimfsOkioRoundTripTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/JimfsOkioRoundTripTest.kt
@@ -23,7 +23,7 @@ import kotlin.io.path.readText
 import kotlin.io.path.writeText
 import kotlin.test.assertEquals
 import okio.FileSystem.Companion.asOkioFileSystem
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class JimfsOkioRoundTripTest {
   private val temporaryDirectory = FileSystem.SYSTEM_TEMPORARY_DIRECTORY

--- a/okio/src/jvmTest/kotlin/okio/JvmSystemFileSystemTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/JvmSystemFileSystemTest.kt
@@ -24,7 +24,7 @@ import kotlin.test.assertFalse
 import kotlin.test.fail
 import kotlin.time.Clock
 import okio.FileSystem.Companion.asOkioFileSystem
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 /**
  * This test will run using [NioSystemFileSystem] by default. If [java.nio.file.Files] is not found

--- a/okio/src/jvmTest/kotlin/okio/LargeStreamsTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/LargeStreamsTest.kt
@@ -24,8 +24,8 @@ import okio.ByteString.Companion.decodeHex
 import okio.HashingSink.Companion.sha256
 import okio.TestUtil.SEGMENT_SIZE
 import okio.TestUtil.randomSource
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 /** Slow running tests that run a large amount of data through a stream.  */
 class LargeStreamsTest {

--- a/okio/src/jvmTest/kotlin/okio/NioTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/NioTest.kt
@@ -15,6 +15,7 @@
  */
 package okio
 
+import java.io.File
 import java.nio.ByteBuffer
 import java.nio.channels.FileChannel
 import java.nio.channels.ReadableByteChannel
@@ -24,14 +25,14 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.text.Charsets.UTF_8
-import org.junit.Rule
-import org.junit.Test
-import org.junit.rules.TemporaryFolder
+import okio.TestUtil.newFile
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 
 /** Test interop between our beloved Okio and java.nio.  */
 class NioTest {
-  @JvmField @Rule
-  var temporaryFolder = TemporaryFolder()
+  @TempDir
+  lateinit var temporaryFolder: File
 
   @Test
   fun sourceIsOpen() {

--- a/okio/src/jvmTest/kotlin/okio/NioTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/NioTest.kt
@@ -25,7 +25,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.text.Charsets.UTF_8
-import okio.TestUtil.newFile
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 

--- a/okio/src/jvmTest/kotlin/okio/OkioKotlinTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/OkioKotlinTest.kt
@@ -48,27 +48,25 @@ class OkioKotlinTest {
 
   @Test fun fileSink() {
     val file = temp.newFile()
-    val sink = file.sink()
-    sink.write(Buffer().writeUtf8("a"), 1L)
+    file.sink().use { it.write(Buffer().writeUtf8("a"), 1L) }
     assertThat(file.readText()).isEqualTo("a")
   }
 
   @Test fun fileAppendingSink() {
     val file = temp.newFile()
     file.writeText("a")
-    val sink = file.sink(append = true)
-    sink.write(Buffer().writeUtf8("b"), 1L)
-    sink.close()
+    file.sink(append = true).use { it.write(Buffer().writeUtf8("b"), 1L) }
     assertThat(file.readText()).isEqualTo("ab")
   }
 
   @Test fun fileSource() {
     val file = temp.newFile()
     file.writeText("a")
-    val source = file.source()
-    val buffer = Buffer()
-    source.read(buffer, 1L)
-    assertThat(buffer.readUtf8()).isEqualTo("a")
+    file.source().use { source ->
+      val buffer = Buffer()
+      source.read(buffer, 1L)
+      assertThat(buffer.readUtf8()).isEqualTo("a")
+    }
   }
 
   @Test fun pathSink() {

--- a/okio/src/jvmTest/kotlin/okio/OkioKotlinTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/OkioKotlinTest.kt
@@ -22,8 +22,9 @@ import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.net.Socket
+import java.nio.file.StandardOpenOption
 import java.nio.file.StandardOpenOption.APPEND
-import okio.TestUtil.newFile
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 
@@ -94,14 +95,13 @@ class OkioKotlinTest {
     assertThat(buffer.readUtf8()).isEqualTo("a")
   }
 
-//  @Disabled("Not sure how to test this") // TODO: Attempt to fix before PR
-//  @Test
-//  fun pathSourceWithOptions() {
-//    val folder = temp.newFolder()
-//    val file = File(folder, "new.txt")
-//    file.toPath().source(StandardOpenOption.CREATE_NEW)
-//    // This still throws NoSuchFileException...
-//  }
+  @Disabled("Not sure how to test this")
+  @Test
+  fun pathSourceWithOptions() {
+    val file = File(temp, "new.txt")
+    file.toPath().source(StandardOpenOption.CREATE_NEW)
+    // This still throws NoSuchFileException...
+  }
 
   @Test fun socketSink() {
     val baos = ByteArrayOutputStream()

--- a/okio/src/jvmTest/kotlin/okio/OkioKotlinTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/OkioKotlinTest.kt
@@ -22,15 +22,13 @@ import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.net.Socket
-import java.nio.file.StandardOpenOption
 import java.nio.file.StandardOpenOption.APPEND
-import org.junit.Ignore
-import org.junit.Rule
-import org.junit.Test
-import org.junit.rules.TemporaryFolder
+import okio.TestUtil.newFile
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 
 class OkioKotlinTest {
-  @get:Rule val temp = TemporaryFolder()
+  @TempDir lateinit var temp: File
 
   @Test fun outputStreamSink() {
     val baos = ByteArrayOutputStream()
@@ -96,14 +94,14 @@ class OkioKotlinTest {
     assertThat(buffer.readUtf8()).isEqualTo("a")
   }
 
-  @Ignore("Not sure how to test this")
-  @Test
-  fun pathSourceWithOptions() {
-    val folder = temp.newFolder()
-    val file = File(folder, "new.txt")
-    file.toPath().source(StandardOpenOption.CREATE_NEW)
-    // This still throws NoSuchFileException...
-  }
+//  @Disabled("Not sure how to test this") // TODO: Attempt to fix before PR
+//  @Test
+//  fun pathSourceWithOptions() {
+//    val folder = temp.newFolder()
+//    val file = File(folder, "new.txt")
+//    file.toPath().source(StandardOpenOption.CREATE_NEW)
+//    // This still throws NoSuchFileException...
+//  }
 
   @Test fun socketSink() {
     val baos = ByteArrayOutputStream()

--- a/okio/src/jvmTest/kotlin/okio/OkioTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/OkioTest.kt
@@ -17,20 +17,20 @@ package okio
 
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.io.File
 import java.nio.file.Files
 import kotlin.text.Charsets.UTF_8
 import okio.TestUtil.SEGMENT_SIZE
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Assert.fail
-import org.junit.Rule
-import org.junit.Test
-import org.junit.rules.TemporaryFolder
+import okio.TestUtil.newFile
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 
 class OkioTest {
-  @JvmField
-  @Rule
-  var temporaryFolder = TemporaryFolder()
+  @TempDir
+  lateinit var temporaryFolder: File
 
   @Test
   fun readWriteFile() {

--- a/okio/src/jvmTest/kotlin/okio/OkioTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/OkioTest.kt
@@ -21,7 +21,6 @@ import java.io.File
 import java.nio.file.Files
 import kotlin.text.Charsets.UTF_8
 import okio.TestUtil.SEGMENT_SIZE
-import okio.TestUtil.newFile
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assertions.fail

--- a/okio/src/jvmTest/kotlin/okio/PipeKotlinTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/PipeKotlinTest.kt
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 
-
 @Timeout(5, unit = TimeUnit.SECONDS)
 class PipeKotlinTest {
 

--- a/okio/src/jvmTest/kotlin/okio/PipeKotlinTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/PipeKotlinTest.kt
@@ -23,17 +23,16 @@ import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.test.assertFailsWith
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.nanoseconds
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Assert.fail
-import org.junit.Rule
-import org.junit.Test
-import org.junit.rules.Timeout as JUnitTimeout
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
 
+
+@Timeout(5, unit = TimeUnit.SECONDS)
 class PipeKotlinTest {
-  @JvmField @Rule
-  val timeout = JUnitTimeout(5, TimeUnit.SECONDS)
 
   @InterceptTest
   private val executorService = TestExecutor(1)
@@ -143,7 +142,7 @@ class PipeKotlinTest {
           sinkBuffer.flush()
         }
 
-        override fun timeout(): Timeout {
+        override fun timeout(): okio.Timeout {
           return sinkBuffer.timeout()
         }
 

--- a/okio/src/jvmTest/kotlin/okio/PipeTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/PipeTest.kt
@@ -25,10 +25,10 @@ import kotlin.time.Duration.Companion.milliseconds
 import okio.ByteString.Companion.decodeHex
 import okio.HashingSink.Companion.sha1
 import okio.TestUtil.assumeNotWindows
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Assert.fail
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
 
 class PipeTest {
   @InterceptTest

--- a/okio/src/jvmTest/kotlin/okio/ReadUtf8LineTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/ReadUtf8LineTest.kt
@@ -18,11 +18,11 @@ package okio
 import app.cash.burst.Burst
 import java.io.EOFException
 import okio.TestUtil.SEGMENT_SIZE
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
-import org.junit.Assert.fail
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
 
 @Burst
 class ReadUtf8LineTest(

--- a/okio/src/jvmTest/kotlin/okio/SegmentSharingTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/SegmentSharingTest.kt
@@ -22,7 +22,7 @@ import okio.ByteString.Companion.encodeUtf8
 import okio.TestUtil.assertEquivalent
 import okio.TestUtil.bufferWithSegments
 import okio.TestUtil.takeAllPoolSegments
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 /** Tests behavior optimized by sharing segments between buffers and byte strings.  */
 class SegmentSharingTest {

--- a/okio/src/jvmTest/kotlin/okio/SocketTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/SocketTest.kt
@@ -34,10 +34,10 @@ import kotlin.test.assertFailsWith
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.measureTime
 import okio.internal.DefaultSocket
-import org.junit.After
-import org.junit.Assume.assumeTrue
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 @Burst
 class SocketTest(val factory: Factory = Factory.Default) {
@@ -45,7 +45,7 @@ class SocketTest(val factory: Factory = Factory.Default) {
   private lateinit var peerSocket: Socket
   private lateinit var peer: AsyncSocket
 
-  @Before
+  @BeforeEach
   fun setUp() {
     val socketPair = factory.createSocketPair()
     this.socket = socketPair[0]
@@ -53,7 +53,7 @@ class SocketTest(val factory: Factory = Factory.Default) {
     this.peer = AsyncSocket(peerSocket)
   }
 
-  @After
+  @AfterEach
   fun tearDown() {
     peer.close()
     socket.source.close()

--- a/okio/src/jvmTest/kotlin/okio/SocketTimeoutTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/SocketTimeoutTest.kt
@@ -24,9 +24,9 @@ import java.net.ServerSocket
 import java.net.Socket
 import java.net.SocketTimeoutException
 import java.util.concurrent.TimeUnit
-import org.junit.Assert.assertTrue
-import org.junit.Assert.fail
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
 
 class SocketTimeoutTest {
   @Test
@@ -77,8 +77,8 @@ class SocketTimeoutTest {
     }
     val elapsed = System.nanoTime() - start
     socket.close()
-    assertTrue("elapsed: $elapsed", TimeUnit.NANOSECONDS.toMillis(elapsed) >= 500)
-    assertTrue("elapsed: $elapsed", TimeUnit.NANOSECONDS.toMillis(elapsed) <= 750)
+    assertTrue(TimeUnit.NANOSECONDS.toMillis(elapsed) >= 500, "elapsed: $elapsed")
+    assertTrue(TimeUnit.NANOSECONDS.toMillis(elapsed) <= 750, "elapsed: $elapsed")
   }
 
   companion object {

--- a/okio/src/jvmTest/kotlin/okio/TestUtil.kt
+++ b/okio/src/jvmTest/kotlin/okio/TestUtil.kt
@@ -15,7 +15,6 @@
  */
 package okio
 
-import java.io.File
 import java.io.IOException
 import java.io.ObjectInputStream
 import java.io.ObjectOutputStream

--- a/okio/src/jvmTest/kotlin/okio/TestUtil.kt
+++ b/okio/src/jvmTest/kotlin/okio/TestUtil.kt
@@ -33,7 +33,6 @@ object TestUtil {
   @JvmField val SEGMENT_POOL_MAX_SIZE = SegmentPool.MAX_SIZE
   const val SEGMENT_SIZE = Segment.SIZE
   const val REPLACEMENT_CODE_POINT: Int = okio.REPLACEMENT_CODE_POINT
-  const val TMP_FILE_PREFIX = "tmp_file"
 
   @JvmStatic fun segmentPoolByteCount() = SegmentPool.byteCount
 
@@ -297,6 +296,4 @@ object TestUtil {
   }
 
   fun assumeNotWindows() = Assumptions.assumeFalse(System.getProperty("os.name").lowercase(Locale.getDefault()).contains("win"))
-
-  fun File.newFile(): File = File.createTempFile(TMP_FILE_PREFIX, null, this)
 }

--- a/okio/src/jvmTest/kotlin/okio/TestUtil.kt
+++ b/okio/src/jvmTest/kotlin/okio/TestUtil.kt
@@ -15,6 +15,7 @@
  */
 package okio
 
+import java.io.File
 import java.io.IOException
 import java.io.ObjectInputStream
 import java.io.ObjectOutputStream
@@ -25,13 +26,14 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import okio.ByteString.Companion.encodeUtf8
-import org.junit.Assume
+import org.junit.jupiter.api.Assumptions
 
 object TestUtil {
   // Necessary to make an internal member visible to Java.
   @JvmField val SEGMENT_POOL_MAX_SIZE = SegmentPool.MAX_SIZE
   const val SEGMENT_SIZE = Segment.SIZE
   const val REPLACEMENT_CODE_POINT: Int = okio.REPLACEMENT_CODE_POINT
+  const val TMP_FILE_PREFIX = "tmp_file"
 
   @JvmStatic fun segmentPoolByteCount() = SegmentPool.byteCount
 
@@ -294,5 +296,7 @@ object TestUtil {
     return reversed.toShort()
   }
 
-  fun assumeNotWindows() = Assume.assumeFalse(System.getProperty("os.name").lowercase(Locale.getDefault()).contains("win"))
+  fun assumeNotWindows() = Assumptions.assumeFalse(System.getProperty("os.name").lowercase(Locale.getDefault()).contains("win"))
+
+  fun File.newFile(): File = File.createTempFile(TMP_FILE_PREFIX, null, this)
 }

--- a/okio/src/jvmTest/kotlin/okio/ThrottlerTakeTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/ThrottlerTakeTest.kt
@@ -19,7 +19,7 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isGreaterThan
 import java.util.concurrent.TimeUnit
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class ThrottlerTakeTest {
   private var nowNanos = 0L

--- a/okio/src/jvmTest/kotlin/okio/ThrottlerTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/ThrottlerTest.kt
@@ -18,8 +18,8 @@ package okio
 import app.cash.burst.InterceptTest
 import kotlin.test.Ignore
 import okio.TestUtil.randomSource
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 @Ignore("These tests are flaky and fail on slower hardware, need to be improved")
 class ThrottlerTest {
@@ -35,7 +35,7 @@ class ThrottlerTest {
   private val executorService = TestExecutor(threads)
   private var stopwatch = Stopwatch()
 
-  @Before fun setup() {
+  @BeforeEach fun setup() {
     throttler.bytesPerSecond(4 * size, 4096, 8192)
     throttlerSlow.bytesPerSecond(2 * size, 4096, 8192)
     stopwatch = Stopwatch()

--- a/okio/src/jvmTest/kotlin/okio/TimeoutTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/TimeoutTest.kt
@@ -16,15 +16,13 @@
 package okio
 
 import java.util.concurrent.TimeUnit
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Rule
-import org.junit.Test
-import org.junit.rules.Timeout as JUnitTimeout
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
 
+@Timeout(5, unit = TimeUnit.SECONDS)
 class TimeoutTest {
-  @JvmField @Rule
-  val timeout = JUnitTimeout(5, TimeUnit.SECONDS)
 
   @Test fun intersectWithReturnsAValue() {
     val timeoutA = Timeout()

--- a/okio/src/jvmTest/kotlin/okio/Utf8Test.kt
+++ b/okio/src/jvmTest/kotlin/okio/Utf8Test.kt
@@ -24,10 +24,10 @@ import kotlin.text.Charsets.UTF_8
 import okio.ByteString.Companion.decodeHex
 import okio.ByteString.Companion.of
 import okio.TestUtil.SEGMENT_SIZE
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 
 class Utf8Test {
   @Test

--- a/okio/src/jvmTest/kotlin/okio/WaitUntilNotifiedTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/WaitUntilNotifiedTest.kt
@@ -21,10 +21,10 @@ import java.io.InterruptedIOException
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration.Companion.milliseconds
 import okio.TestUtil.assumeNotWindows
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Assert.fail
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
 
 @Burst
 class WaitUntilNotifiedTest(

--- a/okio/src/jvmTest/kotlin/okio/ZipBuilder.kt
+++ b/okio/src/jvmTest/kotlin/okio/ZipBuilder.kt
@@ -15,7 +15,8 @@
  */
 package okio
 
-import org.junit.Assume.assumeTrue
+import org.junit.jupiter.api.Assumptions.assumeTrue
+
 
 /**
  * Execute the `zip` command line program to create reference zip files for testing.
@@ -53,7 +54,7 @@ class ZipBuilder(
   fun archiveComment(archiveComment: String) = apply { this.archiveComment = archiveComment }
 
   fun build(): Path {
-    assumeTrue("ZipBuilder doesn't work on Windows", Path.DIRECTORY_SEPARATOR == "/")
+    assumeTrue(Path.DIRECTORY_SEPARATOR == "/", "ZipBuilder doesn't work on Windows")
 
     val archive = directory / "${randomToken(16)}.zip"
     val anyZip64 = entries.any { it.zip64 }

--- a/okio/src/jvmTest/kotlin/okio/ZipBuilder.kt
+++ b/okio/src/jvmTest/kotlin/okio/ZipBuilder.kt
@@ -17,7 +17,6 @@ package okio
 
 import org.junit.jupiter.api.Assumptions.assumeTrue
 
-
 /**
  * Execute the `zip` command line program to create reference zip files for testing.
  *

--- a/okio/src/jvmTest/kotlin/okio/ZipFileSystemJavaTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/ZipFileSystemJavaTest.kt
@@ -19,7 +19,7 @@ import app.cash.burst.InterceptTest
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import okio.Path.Companion.toPath
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class ZipFileSystemJavaTest {
   private val fileSystem = FileSystem.SYSTEM

--- a/okio/src/jvmTest/kotlin/okio/internal/HmacTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/internal/HmacTest.kt
@@ -20,8 +20,8 @@ import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 import kotlin.random.Random
 import okio.ByteString
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
 
 /**
  * Check the [Hmac] implementation against the reference [Mac] JVM implementation.
@@ -43,7 +43,7 @@ class HmacTest(
     mac.update(bytes)
     val hmacValue = mac.digest()
 
-    Assert.assertArrayEquals(expected, hmacValue)
+    Assertions.assertArrayEquals(expected, hmacValue)
   }
 
   @Test
@@ -53,7 +53,7 @@ class HmacTest(
     }
     val hmacValue = mac.digest()
 
-    Assert.assertArrayEquals(expected, hmacValue)
+    Assertions.assertArrayEquals(expected, hmacValue)
   }
 }
 

--- a/okio/src/jvmTest/kotlin/okio/internal/PriorityQueueTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/internal/PriorityQueueTest.kt
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit
 import kotlin.time.Duration.Companion.nanoseconds
 import okio.AsyncTimeout
 import okio.PriorityQueue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class PriorityQueueTest {
   private val TIME_UNIT = TimeUnit.NANOSECONDS

--- a/okio/src/jvmTest/kotlin/okio/internal/ResourceFileSystemTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/internal/ResourceFileSystemTest.kt
@@ -45,7 +45,7 @@ import okio.Path
 import okio.Path.Companion.toPath
 import okio.TestDirectory
 import okio.ZipBuilder
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class ResourceFileSystemTest {
   private val fileSystem = FileSystem.RESOURCES as ResourceFileSystem
@@ -294,23 +294,23 @@ class ResourceFileSystemTest {
 
   @Test
   fun testResourceFromJar() {
-    val path = "LICENSE-junit.txt".toPath()
+    val path = "go/NOTICE".toPath()
 
     val metadata = fileSystem.metadataOrNull(path)!!
 
-    assertThat(metadata.size).isNotNull().isGreaterThan(10000L)
+    assertThat(metadata.size).isNotNull().isGreaterThan(100L)
     assertThat(metadata.isRegularFile).isTrue()
     assertThat(metadata.isDirectory).isFalse()
 
     val content = fileSystem.read(path) { readUtf8Line() }
 
-    assertThat(content).isEqualTo("JUnit")
+    assertThat(content).isEqualTo("The files in this directory are copied from Go:")
   }
 
   @Test
   fun testClassFilesOmittedFromJar() {
-    assertThat(fileSystem.list("/org/junit/rules".toPath())).isEmpty()
-    assertThat(fileSystem.metadataOrNull("/org/junit/Test.class".toPath())).isNull()
+    assertThat(fileSystem.list("/org/junit/jupiter/api/function".toPath())).isEmpty()
+    assertThat(fileSystem.metadataOrNull("/org/junit/jupiter/Test.class".toPath())).isNull()
   }
 
   @Test
@@ -344,7 +344,7 @@ class ResourceFileSystemTest {
     assertThat(metadata?.isDirectory).isNotNull().isTrue()
 
     val files = fileSystem.list(path).map { it.name }
-    assertThat(files).containsAtLeast("matchers", "rules")
+    assertThat(files).containsAtLeast("jupiter", "platform")
     assertThat(files.filter { it.endsWith(".class") }).isEmpty()
   }
 

--- a/okio/src/jvmTest/kotlin/okio/internal/SetBitsOrZeroTest.kt
+++ b/okio/src/jvmTest/kotlin/okio/internal/SetBitsOrZeroTest.kt
@@ -18,7 +18,7 @@ package okio.internal
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import java.util.concurrent.atomic.AtomicInteger
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class SetBitsOrZeroTest {
   @Test

--- a/okio/src/nonWasmTest/kotlin/okio/FakeFileSystemTest.kt
+++ b/okio/src/nonWasmTest/kotlin/okio/FakeFileSystemTest.kt
@@ -26,11 +26,11 @@ import kotlin.time.Duration.Companion.minutes
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
 
-class FakeWindowsFileSystemTest: FakeFileSystemTest(fakeConfig("C:\\".toPath()) {emulateWindows()})
+class FakeWindowsFileSystemTest : FakeFileSystemTest(fakeConfig("C:\\".toPath()) { emulateWindows() })
 
-class FakeUnixFileSystemTest: FakeFileSystemTest(fakeConfig("/".toPath()) {emulateUnix()})
+class FakeUnixFileSystemTest : FakeFileSystemTest(fakeConfig("/".toPath()) { emulateUnix() })
 
-class StrictFakeFileSystemTest : FakeFileSystemTest(fakeConfig( "/".toPath()) {})
+class StrictFakeFileSystemTest : FakeFileSystemTest(fakeConfig("/".toPath()) {})
 
 private fun fakeConfig(temporaryDirectory: Path, fsBlock: FakeFileSystem.() -> Unit): FakeFileSystemTest.Config {
   val clock = FakeClock()
@@ -490,5 +490,4 @@ abstract class FakeFileSystemTest internal constructor(config: Config) : Abstrac
   )
 
   internal class Config(val fakeClock: FakeClock, val fakeFileSystem: FakeFileSystem, val temporaryDirectory: Path)
-
 }

--- a/okio/src/nonWasmTest/kotlin/okio/FakeFileSystemTest.kt
+++ b/okio/src/nonWasmTest/kotlin/okio/FakeFileSystemTest.kt
@@ -26,43 +26,29 @@ import kotlin.time.Duration.Companion.minutes
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
 
-class FakeWindowsFileSystemTest private constructor(clock: FakeClock) : FakeFileSystemTest(
-  fakeFileSystem = FakeFileSystem(clock = clock).also { it.emulateWindows() },
-  fakeClock = clock,
-  temporaryDirectory = "C:\\".toPath(),
-) {
-  constructor() : this(FakeClock())
+class FakeWindowsFileSystemTest: FakeFileSystemTest(fakeConfig("C:\\".toPath()) {emulateWindows()})
+
+class FakeUnixFileSystemTest: FakeFileSystemTest(fakeConfig("/".toPath()) {emulateUnix()})
+
+class StrictFakeFileSystemTest : FakeFileSystemTest(fakeConfig( "/".toPath()) {})
+
+private fun fakeConfig(temporaryDirectory: Path, fsBlock: FakeFileSystem.() -> Unit): FakeFileSystemTest.Config {
+  val clock = FakeClock()
+  return FakeFileSystemTest.Config(clock, FakeFileSystem(clock).apply(fsBlock), temporaryDirectory)
 }
 
-class FakeUnixFileSystemTest private constructor(clock: FakeClock) : FakeFileSystemTest(
-  fakeFileSystem = FakeFileSystem(clock = clock).also { it.emulateUnix() },
-  fakeClock = clock,
-  temporaryDirectory = "/".toPath(),
-) {
-  constructor() : this(FakeClock())
-}
-
-class StrictFakeFileSystemTest private constructor(clock: FakeClock) : FakeFileSystemTest(
-  fakeFileSystem = FakeFileSystem(clock = clock),
-  fakeClock = clock,
-  temporaryDirectory = "/".toPath(),
-) {
-  constructor() : this(FakeClock())
-}
-
-abstract class FakeFileSystemTest internal constructor(
-  private val fakeFileSystem: FakeFileSystem,
-  private val fakeClock: FakeClock,
-  temporaryDirectory: Path,
-) : AbstractFileSystemTest(
-  clock = fakeFileSystem.clock,
-  fileSystem = fakeFileSystem,
-  windowsLimitations = !fakeFileSystem.allowMovingOpenFiles,
-  allowClobberingEmptyDirectories = fakeFileSystem.allowClobberingEmptyDirectories,
+abstract class FakeFileSystemTest internal constructor(config: Config) : AbstractFileSystemTest(
+  clock = config.fakeFileSystem.clock,
+  fileSystem = config.fakeFileSystem,
+  windowsLimitations = !config.fakeFileSystem.allowMovingOpenFiles,
+  allowClobberingEmptyDirectories = config.fakeFileSystem.allowClobberingEmptyDirectories,
   allowAtomicMoveFromFileToDirectory = false,
-  temporaryDirectory = temporaryDirectory,
+  temporaryDirectory = config.temporaryDirectory,
   closeBehavior = CloseBehavior.Closes,
 ) {
+
+  private val fakeFileSystem = config.fakeFileSystem
+  private val fakeClock = config.fakeClock
 
   @Test
   fun openPathsIncludesOpenSink() {
@@ -502,4 +488,7 @@ abstract class FakeFileSystemTest internal constructor(
   internal data class ContentTypeExtra(
     val contentType: String,
   )
+
+  internal class Config(val fakeClock: FakeClock, val fakeFileSystem: FakeFileSystem, val temporaryDirectory: Path)
+
 }

--- a/samples/build.gradle.kts
+++ b/samples/build.gradle.kts
@@ -20,7 +20,8 @@ kotlin {
     val jvmTest by getting {
       dependencies {
         implementation(libs.test.assertk)
-        implementation(libs.test.junit)
+        implementation(libs.test.junit5)
+        implementation(projects.okioTestingSupport)
       }
     }
   }

--- a/samples/src/jvmTest/java/okio/samples/ChannelsTest.kt
+++ b/samples/src/jvmTest/java/okio/samples/ChannelsTest.kt
@@ -17,6 +17,7 @@ package okio.samples
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import java.io.File
 import java.nio.channels.FileChannel
 import java.nio.channels.ReadableByteChannel
 import java.nio.file.Files
@@ -25,16 +26,15 @@ import java.util.EnumSet
 import okio.Buffer
 import okio.Timeout
 import okio.buffer
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Rule
-import org.junit.Test
-import org.junit.rules.TemporaryFolder
+import okio.newFile
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 
 class ChannelsTest {
-  @JvmField
-  @Rule
-  var temporaryFolder = TemporaryFolder()
+  @TempDir
+  lateinit var temporaryFolder: File
 
   @Test
   fun testReadChannel() {

--- a/samples/src/jvmTest/java/okio/samples/SourceMarkerTest.kt
+++ b/samples/src/jvmTest/java/okio/samples/SourceMarkerTest.kt
@@ -21,8 +21,8 @@ import assertk.assertions.isEqualTo
 import java.io.IOException
 import java.util.Arrays
 import okio.Buffer
-import org.junit.Assert.fail
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
 
 class SourceMarkerTest {
   @Test


### PR DESCRIPTION
Basically, the title but here's a summary of the changes:
- I basically switched the JUnit 4 dependency in the **okio** and **samples** modules to JUnit 5 and subsequently updated the imports.
- I have tried to do this with as little changes as possible, but the tests in `FakeFileSystemTest` require updates to their constructors since JUnit 5 doesn't support multiple constructors.
-  I also added a helper function to create a temporary file after migrating from JUnit 4's `TemporaryFolder` to JUnit 5's `@TempDir`

This is the first PR for implementing #1846
