### PR TITLE
Fix an unintended behavior change with base64 padding

### DIFF
--- a/okio/src/appleMain/kotlin/okio/ByteString.kt
+++ b/okio/src/appleMain/kotlin/okio/ByteString.kt
@@ -79,12 +79,12 @@ internal actual constructor(
   actual open fun base64(includePadding: Boolean): String = commonBase64(includePadding = includePadding)
 
   @Deprecated(message = "for binary compatibility", level = DeprecationLevel.HIDDEN)
-  fun base64(): String = commonBase64(includePadding = false)
+  fun base64(): String = commonBase64(includePadding = true)
 
   actual open fun base64Url(includePadding: Boolean): String = commonBase64Url(includePadding = includePadding)
 
   @Deprecated(message = "for binary compatibility", level = DeprecationLevel.HIDDEN)
-  fun base64Url(): String = commonBase64(includePadding = false)
+  fun base64Url(): String = commonBase64(includePadding = true)
 
   actual open fun hex(): String = commonHex()
 

--- a/okio/src/nonAppleMain/kotlin/okio/ByteString.kt
+++ b/okio/src/nonAppleMain/kotlin/okio/ByteString.kt
@@ -73,12 +73,12 @@ internal actual constructor(
   actual open fun base64(includePadding: Boolean): String = commonBase64(includePadding = includePadding)
 
   @Deprecated(message = "for binary compatibility", level = DeprecationLevel.HIDDEN)
-  fun base64(): String = commonBase64(includePadding = false)
+  fun base64(): String = commonBase64(includePadding = true)
 
   actual open fun base64Url(includePadding: Boolean): String = commonBase64Url(includePadding = includePadding)
 
   @Deprecated(message = "for binary compatibility", level = DeprecationLevel.HIDDEN)
-  fun base64Url(): String = commonBase64(includePadding = false)
+  fun base64Url(): String = commonBase64(includePadding = true)
 
   actual open fun hex(): String = commonHex()
 


### PR DESCRIPTION
I inadvertently changed behavior in 3.18.1.

Closes: https://github.com/lysine-dev/okio/issues/1868